### PR TITLE
Build just one message when tweet is sent.

### DIFF
--- a/src/tweeter.coffee
+++ b/src/tweeter.coffee
@@ -94,8 +94,9 @@ module.exports = (robot) ->
         msg.reply "I can't do that. #{err.message} (error #{err.statusCode})"
         return
       if reply['text']
-        msg.send "#{reply['user']['screen_name']} just tweeted: '#{reply['text']}'."
-        return msg.send "To delete, run 'hubot untweet@#{username} #{reply['id_str']}'."
+        message = "#{reply['user']['screen_name']} just tweeted: #{reply['text']}."
+        message += " Delete it with '#{robot.name} untweet@#{username} #{reply['id_str']}'."
+        return msg.send message
       else
         return msg.reply "Hmmm. I'm not sure if the tweet posted. Check the account: http://twitter.com/#{username}"
 


### PR DESCRIPTION
Asynchronous calls to the Campfire/whatever API may result in messages which are out of order:

![screen shot 2014-03-01 at 3 49 41 pm](https://f.cloud.github.com/assets/237985/2302535/0ac3fdca-a183-11e3-9d35-14ef7c370d95.png)
